### PR TITLE
Adjusted grunt step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install
 And do your first build:
 
 ```SHELL
-grunt build
+grunt
 ```
 
 ## Versions


### PR DESCRIPTION
No `grunt build` task is present in the Gruntfile.js.

Only the default `grunt` and `grunt release`.
